### PR TITLE
Add server/client interfaces for remote inference

### DIFF
--- a/infer.py
+++ b/infer.py
@@ -1,9 +1,14 @@
 import os
 from speedrun import BaseExperiment
 
-from loader import ContactPreprocessor
+from loader import ContactPreprocessor, InvalidSetSize
 from models import ContactTracingTransformer
 import torch
+
+import pickle
+import threading
+import typing
+import zmq
 
 
 class InferenceEngine(BaseExperiment):
@@ -38,6 +43,65 @@ class InferenceEngine(BaseExperiment):
             )
             infectiousness = model_output["latent_variable"].numpy()[0, :, 0]
         return dict(contagion_proba=contagion_proba, infectiousness=infectiousness)
+
+
+class InferenceServer(threading.Thread):
+
+    def __init__(
+            self,
+            experiment_directory: typing.AnyStr,
+            port: int = 6688,
+            poll_delay_ms: int = 1000,
+    ):
+        threading.Thread.__init__(self)
+        self.experiment_directory = experiment_directory
+        self.port = port
+        self.poll_delay_ms = poll_delay_ms
+        self.stop_flag = threading.Event()
+
+    def run(self):
+        engine = InferenceEngine(self.experiment_directory)
+        context = zmq.Context()
+        socket = context.socket(zmq.REP)
+        socket.identity = f"inference:{self.port}".encode("ascii")
+        socket.bind(f"tcp://*:{self.port}")
+        poller = zmq.Poller()
+        poller.register(socket, zmq.POLLIN)
+        while not self.stop_flag.is_set():
+            evts = dict(poller.poll(self.poll_delay_ms))
+            if socket in evts and evts[socket] == zmq.POLLIN:
+                hdi = pickle.loads(socket.recv())
+                output = None
+                try:
+                    output = engine.infer(hdi)
+                except InvalidSetSize:
+                    pass  # return None for invalid samples
+                socket.send(pickle.dumps(output))
+        socket.close()
+
+    def stop(self):
+        self.stop_flag.set()
+
+
+class InferenceClient:
+    def __init__(
+            self,
+            target_port: typing.Union[int, typing.List[int]],
+            target_addr: typing.AnyStr = "localhost",
+    ):
+        if isinstance(target_port, int):
+            self.target_ports = [target_port]
+        else:
+            self.target_ports = target_port
+        self.target_addr = target_addr
+        self.context = zmq.Context()
+        self.socket = self.context.socket(zmq.REQ)
+        for port in self.target_ports:
+            self.socket.connect(f"tcp://{target_addr}:{port}")
+
+    def infer(self, sample):
+        self.socket.send(pickle.dumps(sample))
+        return pickle.loads(self.socket.recv())
 
 
 if __name__ == "__main__":

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ addict
 tensorflow==1.15.2
 onnx==1.6
 onnx-tf
+pyzmq

--- a/tests/test.py
+++ b/tests/test.py
@@ -146,6 +146,10 @@ class Tests(unittest.TestCase):
                                  remote_output["contagion_proba"].shape)
                 self.assertEqual(local_output["infectiousness"].shape,
                                  remote_output["infectiousness"].shape)
+                self.assertTrue(np.isclose(local_output["contagion_proba"],
+                                           remote_output["contagion_proba"]).all())
+                self.assertTrue(np.isclose(local_output["infectiousness"],
+                                           remote_output["infectiousness"]).all())
         for s in servers:
             s.stop()
             s.join()

--- a/tests/test.py
+++ b/tests/test.py
@@ -4,6 +4,7 @@ import unittest
 class Tests(unittest.TestCase):
 
     DATASET_PATH = "../data/1k-1-output"
+    EXPERIMENT_PATH = "../exp/DEBUG-0"
     NUM_KEYS_IN_BATCH = 12
 
     def test_model(self):
@@ -105,6 +106,49 @@ class Tests(unittest.TestCase):
         self.assertEqual(
             dataset.extract(sample, "test_results_at_encounter").shape[-1], 1
         )
+
+    def test_inference(self):
+        import numpy as np
+        import infer
+        import loader
+        # this should automatically load-balance inference across servers; see:
+        # https://learning-0mq-with-pyzmq.readthedocs.io/en/latest/pyzmq/multiprocess/multiprocess.html
+        test_ports = [6688, 6689, 6690]
+        servers = [infer.InferenceServer(self.EXPERIMENT_PATH, port)
+                   for port in test_ports]
+        _ = [s.start() for s in servers]
+        local_engine = infer.InferenceEngine(self.EXPERIMENT_PATH)
+        remote_engine = infer.InferenceClient(test_ports, "localhost")
+        dataset = loader.ContactDataset(self.DATASET_PATH)
+        for _ in range(1000):
+            hdi, local_output = None, None
+            try:
+                hdi = dataset.read(
+                    np.random.randint(dataset.num_humans),
+                    np.random.randint(dataset.num_days),
+                )
+                local_output = local_engine.infer(hdi)
+            except loader.InvalidSetSize:
+                pass  # skip samples without encounters
+            # avoid sending a bad sample to remote server
+            remote_output = remote_engine.infer(hdi)
+            if local_output is None:
+                self.assertTrue(remote_output is None)
+            if local_output is not None:
+                for output in [local_output, remote_output]:
+                    self.assertIsInstance(output, dict)
+                    self.assertEqual(len(output), 2)
+                    self.assertIn("contagion_proba", output)
+                    self.assertIn("infectiousness", output)
+                    self.assertIsInstance(output["contagion_proba"], np.ndarray)
+                    self.assertIsInstance(output["infectiousness"], np.ndarray)
+                self.assertEqual(local_output["contagion_proba"].shape,
+                                 remote_output["contagion_proba"].shape)
+                self.assertEqual(local_output["infectiousness"].shape,
+                                 remote_output["infectiousness"].shape)
+        for s in servers:
+            s.stop()
+            s.join()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
With this implementation, multiple servers can be started on a node and they will automatically balance the inference load from clients.

These changes include a new test for the inference engine comparing remote+local outputs.