### PR TITLE
Fix requirements and warn instead of halt when no model ckpt is present

### DIFF
--- a/ctt/inference/infer.py
+++ b/ctt/inference/infer.py
@@ -1,5 +1,6 @@
 import os
 from speedrun import BaseExperiment
+import warnings
 
 from ctt.data_loading.loader import ContactPreprocessor
 from ctt.models.transformer import ContactTracingTransformer
@@ -23,10 +24,12 @@ class InferenceEngine(BaseExperiment):
 
     def load(self):
         path = os.path.join(self.checkpoint_directory, "best.ckpt")
-        assert os.path.exists(path)
-        state = torch.load(path, map_location=torch.device("cpu"))
-        self.model.load_state_dict(state["model"])
-        self.model.eval()
+        if os.path.exists(path):
+            state = torch.load(path, map_location=torch.device("cpu"))
+            self.model.load_state_dict(state["model"])
+            self.model.eval()
+        else:
+            warnings.warn("No model checkpoint found", RuntimeWarning)
         return self
 
     def infer(self, human_day_info):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,12 @@
 torch
-unittest
 numpy
 addict
-git+git://github.com/inferno-pytorch/speedrun.git@p2p_risk_prediction
+speedrun @ git+https://github.com/inferno-pytorch/speedrun.git@p2p_risk_prediction
 zipfile36
 wandb
 tensorflow==2.1
 tensorflow-addons==0.9.1
 onnx==1.6
-git+git://github.com/onnx/onnx-tensorflow.git@c4fc047e7ec71daa6aa8f71e9cc2ee9e5a3768b6#egg=onnx-tf
+onnx-tf @ git+https://github.com/onnx/onnx-tensorflow.git@c4fc047e7ec71daa6aa8f71e9cc2ee9e5a3768b6#egg=onnx-tf
 scipy
 pyzmq

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,6 @@
+# This file is splitted in setup.py to fill the install_requires field
+# Format when using a git end poing should be:
+#  package_name @ git+https://url.git@pathspec#egg=package_name
 torch
 numpy
 addict

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,9 @@
 from setuptools import setup
 
+
+with open('requirements.txt', 'r') as f:
+    requirements = [line.strip() for line in f.readlines()]
+
 setup(
     name='ctt',
     version='0.1',
@@ -8,5 +12,6 @@ setup(
     license='MIT',
     author='Nasim Rahaman',
     author_email='nasim.rahaman@tuebingen.mpg.de',
-    description='Contact Tracing Transformer'
+    description='Contact Tracing Transformer',
+    install_requires=requirements
 )

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 
 with open('requirements.txt', 'r') as f:
-    requirements = [line.strip() for line in f.readlines()]
+    requirements = [line.strip() for line in f.readlines() if not line.startswith("#")]
 
 setup(
     name='ctt',


### PR DESCRIPTION
Needed to have a [working CI](https://github.com/pg2455/covid_p2p_simulation/pull/114) in [pg2455/covid_p2p_simulation](https://github.com/pg2455/covid_p2p_simulation/)